### PR TITLE
fix MinGW build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,8 @@ fi
 LDFLAGS_SAVED="${LDFLAGS}"
 case "$host_os" in
   mingw32 | cygwin)
+    # Remove exception handling (objcopy can get confused with .eh_frame sections otherwise)
+    CPPFLAGS="$CPPFLAGS -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables"
     BIN_LDFLAGS="-Wl,-T"'$(top_srcdir)'"/ldscript"
     LDFLAGS="${LDFLAGS} -Wl,-T${srcdir}/ldscript"
     BUILD_DIRS="stage2"

--- a/ldscript
+++ b/ldscript
@@ -48,6 +48,5 @@ SECTIONS
   }
 }
 
-ASSERT("__rdata_end__"=="edata", ".pdata not empty")
-ASSERT("__bss_end__"  =="end"  , ".edata not empty")
-
+ASSERT(!SIZEOF(.pdata), ".pdata not empty")
+ASSERT(!SIZEOF(.edata), ".edata not empty")


### PR DESCRIPTION
- Use the `SIZEOF()` macro in ldscript, to find if a section is empty or not defined.
- Ensure that `-fno-asynchronous-unwind-tables` is used when checking objcopy behaviour, by setting `CPPFLAGS` in configure.ac. Without this, the objcopy absolute address test fails because gcc on MinGW creates a `.eh_frame` section, that objcopy can't handle.
- Note: To get a working grub4dos using MinGW, you may have to downgrade gcc to 4.6.2 using:

```
     mingw-get upgrade gcc=4.6.2-1
     mingw-get install mpc=0.8.1-1
```

  MinGW users should also run autogen.sh or bootstrap.sh before invoking configure.
