### PR TITLE
hidden sector count fixes for fat12_16_dbr, fat32_dbr, exfat_dbr and ntfs_dbr

### DIFF
--- a/stage2/grldrstart.S
+++ b/stage2/grldrstart.S
@@ -3334,6 +3334,7 @@ nt_part_ofs:
 
 	movw	%ax, %ss	/* stack and BP-relative moves up, too */
 	leaw	-0x20(%bp), %sp
+	pushl	0x8(%si)	/* partition_table_entry.start_sector_ofs (LBA) */
 	sti
 
 	movw	%dx, nt_boot_drive
@@ -3346,6 +3347,7 @@ nt_part_ofs:
 	int	$0x13
 
 	popw	%ds		/* DS=0 */
+	popl	%eax		/* partition_table_entry.start_sector_ofs (LBA) */
 
 	jc	1f		/* No EBIOS */
 	cmpw	$0xAA55, %bx
@@ -3356,6 +3358,7 @@ nt_part_ofs:
 	jnc	1f		# No EBIOS
 	/* EBIOS supported */
 	movb	$0x42, (ebios_nt - 1 - Entry_nt)(%bp)
+	movl	%eax, 0x1c(%bp)	/* copy partition_table_entry.start_sector_ofs to hidden sectors */
 1:
 
 	pushw	%ss		/* SS=0 */
@@ -3637,13 +3640,8 @@ print_ntfs:
 	int	$0x10		/* via TTY mode */
 	cmpb	$0, %al		/* end of string? */
 	jne	1b		/* until done */
-
-	/* The caller will change this to
-	 *	ljmp	$0x9400, $(try_next_partition - _start1)
-	 */
-	jmp 1f
-
-        . = Entry_nt + 0x1e0
+2:
+	jmp 2b
 
 msg_NTFS_Not_Found_Error:
 	.ascii "No "
@@ -3654,12 +3652,6 @@ nt_boot_image:
 msg_DiskReadError_nt:
 	.ascii	"0\0" 
 
-	. = Entry_nt + 0x1f4
-	
-error_go_back:
-1:
-	jmp	1b
-	
 	. = Entry_nt + 0x1fc
 
 	.word	0, 0xAA55

--- a/stage2/grldrstart.S
+++ b/stage2/grldrstart.S
@@ -2725,8 +2725,8 @@ Entry_exfat:
 //	movw	%ax, %ds
 //	movw	%ax, %es
         movw    %bp, %sp                        /* ss:sp=0000:7c00 */
+	pushl	0x8(%si)	                /* partition_table_entry.start_sector_ofs (LBA) */
 	sti
-	pushw	%ax
 
 	movw	%dx, 0x24(%bp)	/* BIOS passes drive number in DL */
 	
@@ -2738,10 +2738,12 @@ Entry_exfat:
 	movb	$0x41, %ah
 	movw	$0x55AA, %bx
 	int	$0x13
+	popl	%eax		                /* partition_table_entry.start_sector_ofs (LBA) */
 	jc	1f		# No EBIOS
 	rorb	%cl   	        # ror cl: D0 C9
 	jnc	1f		# No EBIOS
 	orb	$0x80, 0x16(%bp)  /* EBIOS supported */
+	movl    %eax, 0x40(%bp)	               /* copy partition_table_entry.start_sector_ofs to hidden sectors */
 	jmp	2f
 1:
 	movb		$0x08, %ah
@@ -2750,6 +2752,7 @@ Entry_exfat:
 	andb    $0x3f, %cl
 	movb    %cl, 0x18(%bp)
 2:
+	pushw	%ss
 	popw	%ds
 	        			
 	movl    0x50(%bp), %eax

--- a/stage2/grldrstart.S
+++ b/stage2/grldrstart.S
@@ -1475,6 +1475,7 @@ Entry_12_16:
 	movw	$0x7c00, %bp
 	movw	%bp, %sp        
 	movw	%ax, %ss	/* stack and BP-relative moves up, too */
+	pushl	0x8(%si)	/* partition_table_entry.start_sector_ofs (LBA) */
 	movw	%ax, %ds
 	movw	%ax, %es
 	sti			/* after stack setup, we can use stack */ 
@@ -1489,6 +1490,7 @@ Entry_12_16:
 	int	$0x13
 	popw	%es
 	popw	%ds
+	popl	%eax		/* partition_table_entry.start_sector_ofs (LBA) */
 	jc	1f		/* No EBIOS */
 	cmpw	$0xAA55, %bx
 	jne	1f		/* No EBIOS */
@@ -1496,6 +1498,7 @@ Entry_12_16:
 	jnc	1f              /* No EBIOS */
 	/* EBIOS supported */
 	movb	$0x42, (ebios_12_16 - 1 - Entry_12_16 + 0x7c00)
+	movl	%eax, 0x1c(%bp)	/* copy partition_table_entry.start_sector_ofs to hidden sectors */
 1:
 	/* GET DRIVE PARMS: Calculate start of some disk areas */
 	movzwl	0x0e(%bp), %ebx	/* reserved sectors */

--- a/stage2/grldrstart.S
+++ b/stage2/grldrstart.S
@@ -3547,6 +3547,8 @@ readDisk_nt:
 	pushw	%bx		/* buffer offset */
 	pushw	$1		/* 1 sector to read */
 	pushw	$16		/* size of this parameter block */
+	cmpb	$0x42, (ebios_nt - 1 - Entry_nt)(%bp)
+	je      9f		/* skip both of division by 0 below, avoiding crash caused by fatal interrupt */
 
 	xorl	%ecx, %ecx
 	pushl	0x18(%bp)	/* lo:sectors per track, hi:number of heads */
@@ -3567,6 +3569,7 @@ readDisk_nt:
 	shlb	$6, %ah		/* hi 2bit cylinder ... */
 	orb	%ah, %cl	/* ... should be in CL */
 
+9:
 	movw	$0x201, %ax	/* read 1 sector */
 ebios_nt: /* ebios_nt - 1 points to 0x02 that can be changed to 0x42 */
 

--- a/stage2/grldrstart.S
+++ b/stage2/grldrstart.S
@@ -3252,7 +3252,7 @@ FAT_Address:
 #define NT_FG_GPOS	8
 
 #define nt_boot_drive	-2(%bp)
-#define nt_blocksize	-4(%bp)
+#define nt_blocksize	0xb(%bp)
 #define nt_spc		-5(%bp)
 #define nt_mft_size	-6(%bp)
 #define nt_idx_size	-7(%bp)
@@ -3333,7 +3333,7 @@ nt_part_ofs:
 	movw	$0x7c00, %bp
 
 	movw	%ax, %ss	/* stack and BP-relative moves up, too */
-	leaw	-0x20(%bp), %sp
+	leaw	-0x20(%bp), %sp	/* We need 0x20 bytes for the local variables nt_boot_drive etc. */
 	pushl	0x8(%si)	/* partition_table_entry.start_sector_ofs (LBA) */
 	sti
 
@@ -3375,9 +3375,7 @@ nt_part_ofs:
 	call	readDisk_nt
 1:
 
-	xorl	%eax, %eax
-	movw	0xb(%bp), %ax		// Bytes per sector (blocksize)
-	movw	%ax, nt_blocksize
+	movzwl	nt_blocksize, %eax	// Bytes per sector (blocksize)
 
 	call	convert_to_power_2
 	movb	%cl, %bl
@@ -3605,15 +3603,6 @@ NTFS_Error:
 	jmp	disk_error_nt
 
 
-// Kernel load address, located at 0x1E8
-//	. = Entry_nt + 0x1e8
-
-//nt_boot_image_end:
-
-nt_loadseg_off:
-	.word	0
-	.word	LOADSEG_NT
-
 // Boot image offset and length, located at 0x1EE
 // Lower 11 bit is offset, higher 5 bit is length
 //	. = Entry_nt + 0x1ec
@@ -3657,6 +3646,10 @@ msg_DiskReadError_nt:
 	.word	0, 0xAA55
 
 // Here starts sector #2
+
+nt_loadseg_off:
+	.word	0
+	.word	LOADSEG_NT
 
 // Input:
 //     DI - current mft

--- a/stage2/grldrstart.S
+++ b/stage2/grldrstart.S
@@ -1044,6 +1044,7 @@ Entry_32:
 	movb	$0x41, %ah
 	movw	$0x55AA, %bx
 	int	$0x13
+	movl	0x8(%si), %eax	/* partition_table_entry.start_sector_ofs (LBA) */
 	popw	%ds
 	jc	1f		/* No EBIOS */
 	cmpw	$0xAA55, %bx
@@ -1052,6 +1053,7 @@ Entry_32:
 	jnc	1f              /* No EBIOS */
 	/* EBIOS supported */
 	movb	$0x42, (ebios_32 - 1 - Entry_32 + 0x7c00)
+	movl	%eax, 0x1c(%bp)	/* copy partition_table_entry.start_sector_ofs to hidden sectors */
 1:
 //	movb	(Loadusb_32 - Entry_32 + 0x7c00 +1), %al
 //	decb %al				//al=1,When dl = 00 load


### PR DESCRIPTION
Before this change, fat12_16_dbr, fat32_dbr, exfat_dbr and ntfs_dbr rely on the correct *hidden sectors* value, after this change, for EBIOS they will use the *partition_table_entry.start_sector_ofs* value passed by the MBR boot code in 32-bit *8(%si)*. This copies the behavior of ext2_3_4_dbr, which was already using this latter value.

This change fixes the *No GRLDR* failure reported by the GRUB2 boot code (typically installed by `bootlace.com --floppy /dev/sda1`) when trying to load GRLDR for FAT12, FAT16, FAT32, exFAT and NTFS filesystems.

Before this change, the GRUB2 boot code used as partition and filesystem start offset the *hidden sectors* value in the boot sector (BPB) of the filesystem on the partition. However, this value is often incorrect, for example when creating the filesystem as a image file by the mkfs.vfat, mkfs.exfat and mkfs.ntfs Linux tools, this value is 0 by default, as the tool has no way to know at filesystem creation time where within the the disk image the partition image will be copied to. Also if the partition is moved after it was created, some tools don't update the *hidden sectors* value.

As explained in https://en.wikipedia.org/wiki/Volume_boot_record , the MBR boot code makes partition sector offset value available at boot time in 32-bit *8(%si)* (as part of the MBR partition table entry), thus it can be used instead of the *hidden sectors* value.

However, on some very old systems *8(%si)* may be incorrect. To prevent this change from breaking them, the *8(%si)* value is only used if EBIOS is detected. On systems without EBIOS, the user has already taken care of setting *sectors per track* and *number of heads* in the boot sector (BPB) (because otherwise the system wouldn't boot), and the tool setting these values correctly has probably set *hidden sectors* correctly as well.

I've verified that these changes work end-to-end, for example with the attached FAT16 filesystem (with *hidden sectors* value 0) in [hdfat16.bin.xz.zip](https://github.com/chenall/grub4dos/files/3833534/hdfat16.bin.xz.zip):

```
$ unzip hdfat16.bin.xz.zip
$ xz -cd <hdfat16.bin.xz >hdfat16.bin
$ qemu-system-i386 -m 16 -rtc base=localtime -no-acpi -drive file=hdfat16.bin,index=0,media=disk,format=raw -net none
...
grub> ls
 GRLDR
grub> ls (bd)/
 GRLDR
grub> ls (hd0,0)/
 GRLDR
```

Please note that ext2_3_4_dbr is already correct, it uses the *8(%si)* value in https://github.com/chenall/grub4dos/blob/6dfb6d4213b337d398861e40ff4759319e4a8f37/stage2/grldrstart.S#L1961 .