### PR TITLE
Adding support for building using GCC 15

### DIFF
--- a/configure
+++ b/configure
@@ -5566,6 +5566,26 @@ $as_echo "$fno_common_flag" >&6; }
 if test "x$fno_common_flag" = xyes; then
    STAGE2_CFLAGS="$STAGE2_CFLAGS -fcommon"
 fi
+#gcc 15 and newer has built with -std=gnu23 by default so we add -std=gnu17 to CFLAGS
+# Check if gcc 15 or newer
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether gcc 15 or newer built with -std=gnu23 by default" >&5
+$as_echo_n "checking whether gcc 15 or newer built with -std=gnu23 by default... " >&6; }
+currentgccver="$($CC -dumpversion)"
+gcc15="14.9.0"
+
+if [ "$(printf '%s\n' "$gcc15" "$currentgccver" | sort -V | head -n1)" = "$gcc15" ]; then 
+  C17_common_flag=yes
+else
+  C17_common_flag=no
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $C17_common_flag" >&5
+$as_echo "$C17_common_flag" >&6; }
+
+if test "x$C17_common_flag" = xyes; then
+  CFLAGS="-std=gnu17 $CFLAGS"
+fi
+
 if test "x$with_binutils" != x; then
   # Extract the first word of "objcopy", so it can be a program name with args.
 set dummy objcopy; ac_word=$2


### PR DESCRIPTION
## Summary
Closes #444 
Fixes #444 
This pull request addresses build failures in the `efi` branch of grub4dos when using GCC 15 or newer, as reported in [#444](https://github.com/chenall/grub4dos/issues/444).
It ensures compatibility with newer GCC versions by adjusting the `configure` script to add `-std=gnu17` to the CFLAGS if GCC 15+ is detected, avoiding build errors with incompatible pointer types and function arguments.

## What does this PR do?

- Updates `configure` to detect GCC 15 and newer.
- Adds `-std=gnu17` to CFLAGS for compatibility with the new GCC default (`-std=gnu23`).
- Resolves build errors related to incompatible pointer types and too many arguments to functions.


## Testing

- Tested on Artix GNU/Linux (rolling release) with GCC 15.1.1
- Tested on Ubuntu 24.04.2 LTS WSL with GCC 15.1.0 
-  Tested on Ubuntu  25.10 Hyper-V Manager 15.2.0 
- Ensured that the build passes without the previously encountered errors.

## Additional Notes
- Please let me know if further changes or testing on different environments are required.